### PR TITLE
ci: Install deps after loading deps cache in publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ jobs:
           keys:
             - dependency-cache-v3-{{ checksum "yarn.lock" }}
       - run:
+          name: Install dependencies
+          command: yarn
+      - run:
           name: Prepare NPM auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run:


### PR DESCRIPTION
Because running `yarn` during the `build` job changes the yarn lock file, the dependencies cache
that the publish job depends on doesn't exist. This fix ensures that even if that's the case, the
`publish` job installs the dependencies it need to do its job.