### PR TITLE
build: Force semantic-release to use SSH instead of HTTPS to git push

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "esnext": "es/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/huy-nguyen/squarify.git"
+    "url": "git://github.com/huy-nguyen/squarify.git"
   },
   "scripts": {
     "test": "jest --coverage --verbose",


### PR DESCRIPTION
This is done to fix failed build https://circleci.com/gh/huy-nguyen/squarify/259.